### PR TITLE
EeveeSpotify 3.1

### DIFF
--- a/OpenSpotifySafariExtension.appex/_locales/en/messages.json
+++ b/OpenSpotifySafariExtension.appex/_locales/en/messages.json
@@ -4,7 +4,7 @@
         "description": "The display name for the extension."
     },
     "extension_description": {
-        "message": "Displays an Open in Spotify alert for sideloaded Spotify",
+        "message": "Displays an Open in Spotify alert for sideloaded Spotify. Requires EeveeSpotify 3.1 or newer.",
         "description": "Description of what the extension does."
     }
 }

--- a/OpenSpotifySafariExtension.appex/content.js
+++ b/OpenSpotifySafariExtension.appex/content.js
@@ -7,10 +7,8 @@ browser.runtime.onMessage.addListener((request, sender, sendResponse) => {
 });
 
 function afterNavigate() {
-    const newPathname = window.location.pathname.replace(/\/intl-\w+\//g, "/");
-
-    if (/album|artist|episode|playlist|show|track|user/.test(newPathname)) {
-        window.location.href = `spotify:/${newPathname}`;
+    if (window.location.pathname != "/") {
+        window.location.href = "spotify://eevee/" + window.location.host + window.location.pathname
     }
 }
 

--- a/OpenSpotifySafariExtension.appex/manifest.json
+++ b/OpenSpotifySafariExtension.appex/manifest.json
@@ -20,7 +20,7 @@
 
     "content_scripts": [{
         "js": [ "content.js" ],
-        "matches": [ "*://*.spotify.com/*" ]
+        "matches": [ "*://*.spotify.com/*", "*://spotify.app.link/*" ]
     }],
 
     "action": {


### PR DESCRIPTION
In version 3.1 of EeveeSpotify, I improved link support. OpenSpotifySafariExtension didn't work well and didn't work at all in some cases, such as with Spotify Jam links. I implemented SceneDelegate hook in the tweak. It hooks the `openURLContexts` method and calls `continueUserActivity` if the link is from OpenSpotifySafariExtension (see https://github.com/whoeevee/EeveeSpotify/commit/f1aababc452f99f9b77e8d8d171923516b973508). It works flawlessly with all links.

Yeah, it makes OpenSpotifySafariExtension compatible only with EeveeSpotify, but I believe EeveeSpotify is the only reason to use sideloaded Spotify now.